### PR TITLE
fix(docs): mention teams in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ monorting.
 The Performance WG is made up of volunteers, you do not need to be a member to participate, but once you participate
 please open a PR to add youself here.
 
+Two teams exist for mentioning the group and managing access:
+
+- @expressjs/perf-wg: everyone participating in the WG has write access to this repo
+- @expressjs/perf-wg-captains: the repository captians as per Express project guidelines
+
 ### Team Members
 
-- [Wes Todd](https://github.com/wesleytodd)
+- [Wes Todd](https://github.com/wesleytodd) (Captain)
 
 ## Meetings
 


### PR DESCRIPTION
I setup the two teams, just mentioning them here.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
