### PR TITLE
Fix the broken link and replace it with the correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Two teams exist for mentioning the group and managing access:
 - [Jean Burellier](https://github.com/sheplu)
 - [Sebastian Beltran](https://github.com/bjohansebas)
 - [Ulises Gascón](https://github.com/ulisesGascon)
+- [Murat Kirazkaya](https://github.com/GroophyLifefor)
 
 ## Meetings
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ in the [OpenJS Foundation Slack](https://openjsf.org/collaboration) for realtime
 
 ## Code of Conduct
 
-The [Express Project's CoC](https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md) applies to this repo.
+The [Express Project's CoC](https://github.com/expressjs/express?tab=coc-ov-file#readme) applies to this repo.
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ in the [OpenJS Foundation Slack](https://openjsf.org/collaboration) for realtime
 
 ## Code of Conduct
 
-The [Express Project's CoC](https://github.com/expressjs/express?tab=coc-ov-file#readme) applies to this repo.
+The [Express Project's CoC](https://github.com/expressjs/.github/blob/master/CODE_OF_CONDUCT.md) applies to this repo.
 


### PR DESCRIPTION
Old link: https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md

![image](https://github.com/user-attachments/assets/9d32b5b7-2b10-43bf-8aa9-d8357fe8486a)

New link: https://github.com/expressjs/express?tab=coc-ov-file#readme

![image](https://github.com/user-attachments/assets/5e7227bf-1969-42a8-81d4-990cc2c7c3ab)

