### PR TITLE
Added Recent Meeting Notes and Standardize Format

### DIFF
--- a/meetings/2025-05-14.md
+++ b/meetings/2025-05-14.md
@@ -1,0 +1,38 @@
+# Performance Working Group Meeting Notes – 2025-05-14
+
+### Meta Information
+
+- GitHub Issue: [#8](https://github.com/expressjs/perf-wg/issues/8)
+
+
+### Discussions at the Meeting
+
+- @wesleytodd were shown a cup with the used Express logo
+- Need to define goals 
+- To define benchmarking philosophy (micro, integration, end-to-end).
+- Way: Track Express performance over new versions rather than other frameworks.
+- Focus more on real-world Express usage rather than synthetic Hello World benchmarks.
+- @wesleytodd emphasized building benchmarks that can connect sub-package changes to observable performance changes in full Express apps.
+- @wesleytodd proposed using flame graphs and CPU metrics (via Linux 'perf', OpenTelemetry, etc.).
+- @UlisesGascon NodeSource's NSolid was proposed as a production-grade solution for collecting deep insights without intrusive code.
+- @GroophyLifefor proposed his abstractor-based benchmark framework, used in his observability platform Yelix Cloud for macro/micro performance collection.
+- We talked about how Express is getting slowed down because of the backward compatibility layers.
+- @GroophyLifefor proposed anonymous middleware functions were called out as a major problem for observability, suggested optionally support named middleware functions.
+
+---
+
+### Shared Resources
+
+- @UlisesGascon NSolid (NodeSource): [https://nodesource.com/products/nsolid](https://nodesource.com/products/nsolid)
+- @GroophyLifefor's abstractor example: [https://github.com/yelix-cloud/js-hono-deno/blob/main/src/Hono.ts](https://github.com/yelix-cloud/js-hono-deno/blob/main/src/Hono.ts)
+
+---
+
+### Call to Action
+
+- Open issues/PRs in the [perf-wg repo](https://github.com/expressjs/perf-wg).
+- Add ideas or edits to [issue #3](https://github.com/expressjs/perf-wg/issues/3).
+- Share your work via a GitHub issue, repository or PR.
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊

--- a/meetings/2025-06-11.md
+++ b/meetings/2025-06-11.md
@@ -1,0 +1,30 @@
+# Performance Working Group Meeting Notes – 2025-06-11
+
+### Meta Information
+
+- GitHub Issue: [#16](https://github.com/expressjs/perf-wg/issues/16)
+
+
+### Discussions at the Meeting
+
+- Focus is on **evaluating** performance changes, not teaching how to write fast code.
+- Agreed to define clear metrics (latency, throughput, memory).
+- Plan to build tools for running and interpreting benchmarks.
+- Tests will be split into unit benchmarks and e2e app-level load tests.
+- Work will continue from [PR #18](https://github.com/expressjs/perf-wg/pull/18).
+
+---
+
+### Shared Resources
+
+- **Perf Questions** – What should tests answer: [Issue #15](https://github.com/expressjs/perf-wg/issues/15)  
+- **Test Scaffolding** – Initial setup to build on: [PR #18](https://github.com/expressjs/perf-wg/pull/18)
+
+---
+
+### Call to Action
+
+- Help refine test questions and contribute to the test suite.
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊

--- a/meetings/2025-07-09.md
+++ b/meetings/2025-07-09.md
@@ -1,0 +1,38 @@
+# Performance Working Group Meeting Notes – 2025-07-09
+
+### Meta Information
+
+- GitHub Issue: [#25](https://github.com/expressjs/perf-wg/issues/25)
+
+
+### Discussions at the Meeting
+
+- The **Working Group Charter** was merged ([#26](https://github.com/expressjs/perf-wg/pull/26)) after discussion; agreed it's a starting point for future updates.
+- Adrian Estrada suggested **heap profiles instead of heap snapshots.**
+- @wesleytodd demoed the **benchmarking tooling** using Docker, autocannon, and flamegraphs. It supports comparing across Node versions and collecting detailed result JSONs.
+- @bjohansebas proposed using **WIBY** for future work involving package overrides in benchmarks.
+- @ulisesgascon (Docker Captain) offered to help with higher Docker Hub tiers if needed. He and Adrian Estrada recommended using **Docker Hub** to host benchmark images for cloud testing.
+- @muratkirazkaya suggested using **Dagger** to make container configurations cleaner and code-driven.
+- Discussion on creating a **dashboard** to visualize benchmark results and system metrics. NodeSource may contribute a base version of their internal dashboard.
+- Importance of defining **resource boundaries** (e.g., memory, CPU, architecture) for consistent benchmarking was noted.
+
+---
+
+### Shared Resources
+
+- **Meeting Agenda** – Discussion topics and attendees: [Agenda #25](https://github.com/expressjs/perf-wg/issues/25)
+- **Charter Draft PR** – Initial version of the group's charter: [PR #26](https://github.com/expressjs/perf-wg/pull/26)
+- **Benchmark Dashboard Proposal** – Placeholder for dashboard spec: [Issue #28](https://github.com/expressjs/perf-wg/issues/28)
+- **Query Parser Benchmarks** – Example performance comparisons: [Wes Todd's Gist](https://gist.github.com/wesleytodd/c3579afd638faff996dcce364ac90775)
+- **Board View** – Project planning view for the group: [GitHub Project #9](https://github.com/orgs/expressjs/projects/9)
+
+---
+
+### Call to Action
+
+- Open issues/PRs in the [perf-wg repo](https://github.com/expressjs/perf-wg).
+- Add ideas or edits to [Issue #28](https://github.com/expressjs/perf-wg/issues/28) (dashboarding spec).
+- Share your work via a GitHub issue, repository, or PR.
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊

--- a/meetings/2025-07-23.md
+++ b/meetings/2025-07-23.md
@@ -1,0 +1,64 @@
+# Performance Working Group Meeting Notes – 2025-07-23
+
+### Meta Information
+
+- GitHub Issue: [#27](https://github.com/expressjs/perf-wg/issues/27)
+
+### Discussions at the Meeting
+
+- @muratkirazkaya presented [expf](https://github.com/GroophyLifefor/expf) that a **Docker image for performance testing runner**:
+
+  - Compares **latest NPM package** vs. **candidate source code** to detect regressions.
+  - Supports custom templates (e.g., Autocannon), multiple node versions parallelly and multiple test folders.
+  - Built to run on **GitHub Actions** and locally via Docker, enabling reproducible tests across platforms.
+  - Murat emphasized that the tool benchmarks **Express against itself**, rather than other frameworks.
+
+- **Noted**: The runner (expf) will be tested on Windows environments to ensure cross-platform functionality.
+  - Current CI uses Ubuntu runners, but the Docker image is portable and expected to work on Windows and macOS as well.
+- @ulisesgascon shared that a **Docker Hub org** is ready for CI-based image publishing.
+
+  - While team access is limited, publishing will rely on automation using CI secrets or tokens.
+
+- **Issue #3 (Recurring Meetings)**:
+
+  - Decided to remove from active agenda; regular meetings are now established.
+
+- **Issue #27 (Public Benchmarks)**:
+
+  - Proposal to maintain/update public benchmark repositories testing Express performance.
+  - Jon noted it’s a low-priority item unless someone volunteers, but the group can offer guidance to contributors.
+  - Murat clarified that while **cross-framework benchmarks are not dismissed**, the current focus is on **internal regressions** to ensure Express maintains or improves its own performance over time.
+
+- **Reference Application Strategy**:
+
+  - @jonchurch suggested using **real-world Express apps** to benchmark performance across Express versions.
+  - @kjugi opened an issue to define the types of apps the group should support.
+  - The goal is to test performance of different Express versions under realistic usage patterns.
+
+- **Issue #29 (Dashboard Integration)**:
+  - @edsadr (NodeSource) offered an **open-source React-based dashboard**.
+    - Feeds on JSON data and can be tailored to WG requirements.
+  - WG needs to define what **metrics and views** should be supported.
+  - Murat emphasized that dashboarding is an **active priority**, and contributor support is welcome.
+
+---
+
+### Shared Resources
+
+- **Expf Repository** – Project use case for perf wg: https://github.com/GroophyLifefor/expf
+- **Meeting Agenda** – Topics and participants: [[Agenda #28](https://github.com/expressjs/perf-wg/issues/28)](https://github.com/expressjs/perf-wg/issues/28)
+- **Public Benchmarks** – External benchmark maintenance: [[Issue #27](https://github.com/expressjs/perf-wg/issues/27)](https://github.com/expressjs/perf-wg/issues/27)
+- **Dashboard Proposal** – NodeSource contribution thread: [[Issue #29](https://github.com/expressjs/perf-wg/issues/29)](https://github.com/expressjs/perf-wg/issues/29)
+- **Reference App PR** – Sample app for internal benchmarking: [[PR #24](https://github.com/expressjs/perf-wg/pull/24)](https://github.com/expressjs/perf-wg/pull/24)
+- **Historical Meeting Coordination** – Closed issue: [[Issue #23](https://github.com/expressjs/perf-wg/issues/23)](https://github.com/expressjs/perf-wg/issues/23)
+
+---
+
+### Call to Action
+
+- Contribute to defining **dashboard requirements** in [[#28](https://github.com/expressjs/perf-wg/issues/28)](https://github.com/expressjs/perf-wg/issues/28).
+- Help shape or build **reference apps** via discussion and issues.
+- If interested in external benchmarks, volunteer to help update public repositories.
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊

--- a/meetings/template.md
+++ b/meetings/template.md
@@ -1,0 +1,27 @@
+# Performance Working Group Meeting Notes – YYYY-MM-DD
+
+### Meta Information
+
+- GitHub Issue: [#\<number\>](https://github.com/expressjs/perf-wg/issues/\<number\>)
+
+
+### Discussions at the Meeting
+
+- Something happened during the meeting.
+  - The sub content of the what happened
+- Another discussion point.
+
+---
+
+### Shared Resources
+
+- **Title** – description: -link-
+
+---
+
+### Call to Action
+
+- This is an action that is certain to be of help to those who want to contribute.
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊


### PR DESCRIPTION
Added past meeting notes for
- 2025-05-14
- 2025-06-11
- 2025-07-09
- 2025-07-23 

and added a template(`/meetings/template.md`) for future meetings

### Context
- closes https://github.com/expressjs/perf-wg/issues/27
- closes https://github.com/expressjs/perf-wg/issues/25
- closes https://github.com/expressjs/perf-wg/issues/8
- closes https://github.com/expressjs/perf-wg/issues/16

cc: @expressjs/perf-wg @expressjs/perf-wg-captains 

_edited by @UlisesGascon to include cross references_