### PR TITLE
fix typo in path for meeting workflow

### DIFF
--- a/.github/workflows/meeting.yml
+++ b/.github/workflows/meeting.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
       paths:
-        - '.github/workflows/meetings.yml'
+        - '.github/workflows/meeting.yml'
         - '.github/ISSUE_TEMPLATE/meeting.md'
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
The meeting workflow had a typo in the path allowlist for running on PR changes.