### PR TITLE
[DRAFT] Multi Runners Proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 results
 perf/load/*/package-lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -74,7 +74,225 @@ The Performance Working Group uses [GitHub issues](https://github.com/expressjs/
 The discussions are open to the public and anyone may participate. Also, the group uses the channel `#express-perf-wg`
 in the [OpenJS Foundation Slack](https://openjsf.org/collaboration) for realtime discussions.
 
+## How to Run the Load Tests
+
+### Requirements
+- Node.js v22 or higher
+- Docker (for containerized runners)
+
+### Quick Start
+
+1. **Install dependencies**
+   ```bash
+   node --run setup
+   ```
+
+2. **Run basic test with vanilla Node.js**
+   ```bash
+   node --run test:load
+   ```
+
+### CLI Usage
+
+#### Basic Commands
+
+```bash
+# Run with default vanilla Node.js runner
+node --run load -- --test="@expressjs/perf-load-example"
+
+# Run with specific runner
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-nsolid"
+
+# Run with overrides
+node --run load -- --test="@expressjs/perf-load-example" --overrides='{"express":"5.0.0"}'
+
+# Run with specific runner and overrides
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-nsolid" --overrides='{"express":"5.0.0"}'
+
+
+# Compare results
+node --run compare -- result-A.json result-B.json
+```
+
+#### Runner-Specific Examples
+
+```bash
+# Vanilla Node.js (baseline performance)
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-vanilla"
+
+# N|Solid with built-in monitoring
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-nsolid"
+
+# Node.js with Datadog APM (when available)
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-datadog"
+
+# Node.js with New Relic APM (when available)
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-newrelic"
+```
+
+### Programmatic Usage
+
+#### Basic Import and Usage
+
+```javascript
+// Import specific runner
+import vanillaRunner from '@expressjs/perf-runner-vanilla';
+import nsolidRunner from '@expressjs/perf-runner-nsolid';
+
+// Run single test
+const results = await vanillaRunner({
+  test: '@expressjs/perf-load-example',
+  overrides: { express: '5.0.0' }
+});
+
+console.log(`Requests/sec: ${results.clientResults.requests.mean}`);
+```
+
+#### Performance Comparison Script
+
+```javascript
+import vanillaRunner from '@expressjs/perf-runner-vanilla';
+import nsolidRunner from '@expressjs/perf-runner-nsolid';
+
+async function compareRuntimes() {
+  const testConfig = {
+    test: '@expressjs/perf-load-example',
+    overrides: { express: 'latest' }
+  };
+
+  console.log('Running performance comparison...');
+
+  // Run tests in parallel
+  const [vanillaResults, nsolidResults] = await Promise.all([
+    vanillaRunner(testConfig),
+    nsolidRunner(testConfig)
+  ]);
+
+  // Compare results
+  const vanillaRPS = vanillaResults.clientResults.requests.mean;
+  const nsolidRPS = nsolidResults.clientResults.requests.mean;
+  const overhead = ((vanillaRPS - nsolidRPS) / vanillaRPS * 100).toFixed(2);
+
+  console.log('Performance Comparison:');
+  console.log(`Vanilla Node.js: ${vanillaRPS.toFixed(0)} req/sec`);
+  console.log(`N|Solid:        ${nsolidRPS.toFixed(0)} req/sec`);
+  console.log(`Overhead:       ${overhead}%`);
+}
+
+compareRuntimes().catch(console.error);
+```
+
+#### Advanced Configuration
+
+```javascript
+import { createRunner } from '@expressjs/perf-runner-shared';
+
+// Create custom runner configuration
+const customRunner = createRunner({
+  type: 'custom',
+  runtime: 'node.js',
+  apm: 'custom-monitoring',
+  capabilities: ['profiling', 'tracing'],
+  env: {
+    RUNTIME_TYPE: 'custom',
+    CUSTOM_CONFIG: 'enabled'
+  }
+});
+
+// Use with abort controller for cancellation
+const controller = new AbortController();
+const results = await customRunner({
+  test: '@expressjs/perf-load-example',
+  signal: controller.signal
+});
+```
+
+### Available Runners
+
+| Runner | Description | Use Case | Status |
+|--------|-------------|----------|--------|
+| `@expressjs/perf-runner-vanilla` | Standard Node.js runtime | Baseline performance measurements | Available |
+| `@expressjs/perf-runner-nsolid` | N|Solid runtime with built-in monitoring | Enterprise monitoring capabilities | Available |
+| `@expressjs/perf-runner-datadog` | Node.js + Datadog APM agent | Datadog APM overhead analysis | Coming soon |
+| `@expressjs/perf-runner-newrelic` | Node.js + New Relic APM agent | New Relic APM overhead analysis | Coming soon |
+
+### Performance Analysis Examples
+
+#### CLI-based Comparison
+
+```bash
+# Step 1: Run baseline test
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-vanilla"
+# Output: results/vanilla-result-123456789.json
+
+# Step 2: Run N|Solid test  
+node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-nsolid"
+# Output: results/nsolid-result-123456790.json
+
+# Step 3: Compare results
+node --run compare -- results/vanilla-result-123456789.json results/nsolid-result-123456790.json
+```
+
+#### Programmatic Analysis
+
+```javascript
+import fs from 'node:fs/promises';
+
+async function runPerformanceAnalysis() {
+  // Test configuration
+  const tests = [
+    { name: 'Express Hello World', test: '@expressjs/perf-load-example' },
+    { name: 'Express with Query', test: '@expressjs/perf-load-extended-query' }
+  ];
+
+  const runners = [
+    { name: 'Vanilla', runner: vanillaRunner },
+    { name: 'N|Solid', runner: nsolidRunner }
+  ];
+
+  const results = {};
+
+  // Run all combinations
+  for (const test of tests) {
+    results[test.name] = {};
+    
+    for (const { name, runner } of runners) {
+      console.log(`Running ${test.name} with ${name}...`);
+      
+      const result = await runner({ test: test.test });
+      results[test.name][name] = {
+        requestsPerSec: result.clientResults.requests.mean,
+        latencyP95: result.clientResults.latency.p95,
+        memoryUsage: result.serverMetadata.memory
+      };
+    }
+  }
+
+  // Save comprehensive report
+  await fs.writeFile('performance-report.json', JSON.stringify(results, null, 2));
+  console.log('Performance analysis complete. Results saved to performance-report.json');
+}
+
+### Runner Development
+
+To create a new runner, extend the shared runner infrastructure:
+
+```javascript
+// packages/runner-custom/index.mjs
+import { createRunner } from '@expressjs/perf-runner-shared';
+
+export default createRunner({
+  type: 'custom',
+  runtime: 'node.js',
+  apm: 'custom-apm',
+  capabilities: ['custom-profiling'],
+  env: {
+    RUNTIME_TYPE: 'custom',
+    CUSTOM_SETTING: 'enabled'
+  }
+});
+```
+
 ## Code of Conduct
 
 The [Express Project's CoC](https://github.com/expressjs/.github/blob/master/CODE_OF_CONDUCT.md) applies to this repo.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,18 @@
       "resolved": "packages/runner-docker",
       "link": true
     },
+    "node_modules/@expressjs/perf-runner-nsolid": {
+      "resolved": "packages/runner-nsolid",
+      "link": true
+    },
+    "node_modules/@expressjs/perf-runner-shared": {
+      "resolved": "packages/runner-shared",
+      "link": true
+    },
+    "node_modules/@expressjs/perf-runner-vanilla": {
+      "resolved": "packages/runner-vanilla",
+      "link": true
+    },
     "node_modules/@expressjs/perf-servers-express-extended-query": {
       "resolved": "servers/express-extended-query",
       "link": true
@@ -5937,6 +5949,36 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",
         "rollup": "^4.46.2"
+      }
+    },
+    "packages/runner-nsolid": {
+      "name": "@expressjs/perf-runner-nsolid",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@expressjs/perf-runner-shared": "^1.0.0"
+      }
+    },
+    "packages/runner-shared": {
+      "name": "@expressjs/perf-runner-shared",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@expressjs/perf-autocannon": "^1.0.0",
+        "@expressjs/perf-metadata": "^1.0.0",
+        "@pkgjs/nv": "^0.2.2"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "rollup": "^4.46.2"
+      }
+    },
+    "packages/runner-vanilla": {
+      "name": "@expressjs/perf-runner-vanilla",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@expressjs/perf-runner-shared": "^1.0.0"
       }
     },
     "packages/servers": {

--- a/packages/runner-nsolid/Dockerfile
+++ b/packages/runner-nsolid/Dockerfile
@@ -1,0 +1,52 @@
+# N|Solid Settings
+ARG NODE_VERSION="iron"
+ARG NODE_BASE="latest"
+ARG RUNNER_TYPE="nsolid"
+
+FROM nodesource/nsolid:${NODE_VERSION}-${NODE_BASE}
+
+# Switch to root to install packages
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      linux-perf \
+      jq \
+      git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create perf symlink if it doesn't exist
+RUN if [ ! -f /usr/bin/perf ] && [ -f /usr/bin/perf_5.10 ]; then \
+      ln -s /usr/bin/perf_5.10 /usr/bin/perf; \
+    fi
+
+# Setup @mmarchini/observe
+RUN <<-EOF
+  npm install -g @mmarchini/observe@^3.0.0
+  chown -R node:node /usr/local/lib/node_modules
+  chown -R node:node /usr/local/bin/observe
+EOF
+
+USER node
+WORKDIR /home/node
+
+# Setup FlameGraph tools
+RUN git clone https://github.com/brendangregg/FlameGraph.git
+
+VOLUME ["/home/node/repo"]
+VOLUME ["/home/node/results"]
+EXPOSE 3000 9229
+
+# Copy shared utilities directly from runner-shared
+COPY runner-shared/metadata-bundle.mjs metadata.mjs
+COPY runner-shared/overrides.mjs overrides.mjs
+COPY runner-shared/scripts/start.sh start.sh
+
+# Set runtime type for this container
+ENV RUNTIME_TYPE=nsolid
+
+# N|Solid specific environment variables
+ENV NSOLID_APPNAME="express-benchmark"
+ENV NSOLID_TAGS="benchmark,performance"
+
+ENTRYPOINT ["./start.sh"]

--- a/packages/runner-nsolid/index.mjs
+++ b/packages/runner-nsolid/index.mjs
@@ -1,0 +1,16 @@
+import { createRunner } from '@expressjs/perf-runner-shared';
+
+export default createRunner({
+  type: 'nsolid',
+  runtime: 'N|Solid',
+  apm: 'built-in',
+  capabilities: ['profiling', 'flamegraphs', 'heap-snapshots', 'perf-data', 'nsolid-monitoring', 'cpu-profiling', 'heap-profiling'],
+  nodeVersion: 'iron',
+  nodeBase: 'latest',
+  env: {
+    RUNTIME_TYPE: 'nsolid',
+    NSOLID_APPNAME: 'express-benchmark',
+    NSOLID_TAGS: 'benchmark,performance',
+    NSOLID_SAAS: ''
+  }
+});

--- a/packages/runner-nsolid/package.json
+++ b/packages/runner-nsolid/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@expressjs/perf-runner-nsolid",
+  "version": "1.0.0",
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "node --run build",
+    "build": "node --run shared:build",
+    "run": "node --run shared:run",
+    "shared:build": "../runner-shared/scripts/build.sh iron latest nsolid",
+    "shared:run": "../runner-shared/scripts/run.sh"
+  },
+  "keywords": ["express", "performance", "benchmark", "nsolid", "nodesource"],
+  "author": "",
+  "license": "ISC",
+  "description": "N|Solid runner for Express performance benchmarks with built-in monitoring",
+  "dependencies": {
+    "@expressjs/perf-runner-shared": "^1.0.0"
+  }
+}

--- a/packages/runner-shared/index.mjs
+++ b/packages/runner-shared/index.mjs
@@ -1,0 +1,199 @@
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import ac from '@expressjs/perf-autocannon';
+import { collectMetadata } from '@expressjs/perf-metadata';
+import nv from '@pkgjs/nv';
+
+export function createRunner(runnerConfig = {}) {
+  const {
+    type = 'unknown',
+    runtime = 'node.js',
+    apm = 'none',
+    capabilities = [],
+    env = {},
+    dockerFile = 'Dockerfile',
+    nodeVersion,  // Allow runner-specific node version
+    nodeBase      // Allow runner-specific base OS
+  } = runnerConfig;
+
+  async function buildContainer(opts = {}) {
+    return new Promise(async (resolve, reject) => {
+      // Use runner-specific version if provided, otherwise use CLI option
+      let nodeVer, os;
+      
+      if (nodeVersion && nodeBase) {
+        // Use runner-specific configuration
+        nodeVer = nodeVersion;
+        os = nodeBase;
+      } else {
+        // Fall back to CLI configuration
+        const vers = await nv(opts.node, {
+          latestOfMajorOnly: true
+        });
+        nodeVer = vers?.[0]?.version || 'lts';
+        os = 'bookworm';
+      }
+
+      const cp = execFile(
+        join(import.meta.dirname, 'scripts', 'build.sh'),
+        [
+          nodeVer,
+          os,
+          type // Pass runner type to build script
+        ],
+        { cwd: import.meta.dirname }
+      );
+      
+      cp.on('exit', () => {
+        resolve({
+          tag: `expf-runner-${type}:${nodeVer}-${os}`,
+          node: nodeVer,
+          type,
+          runtime,
+          apm
+        });
+      });
+      cp.on('error', reject);
+      cp.stdout.on('data', (d) => process.stdout.write(d));
+      cp.stderr.on('data', (d) => process.stderr.write(d));
+    });
+  }
+
+  function startServer(opts = {}) {
+    return new Promise((resolve, reject) => {
+      if (opts?.signal.aborted) {
+        return reject(opts.signal.reason);
+      }
+
+      const args = [
+        opts.cwd,
+        opts.repo,
+        opts.repoRef,
+        opts.test,
+        opts.tag,
+      ];
+
+      if (opts.overrides) {
+        args.push(opts.overrides);
+      }
+
+      // Pass runtime environment variables
+      const envVars = { ...env, RUNTIME_TYPE: type };
+      
+      const cp = execFile(
+        join(import.meta.dirname, 'scripts', 'run.sh'), 
+        args, 
+        { env: { ...process.env, ...envVars } }
+      );
+
+      const server = {
+        metadata: {
+          url: new URL('http://localhost:3000'),
+          dockerTag: opts.tag,
+          nodeVersion: opts.node,
+          runnerType: type,
+          runtime,
+          apm,
+          capabilities
+        },
+        status: 'starting',
+        close: () => {
+          return new Promise((closeResolve) => {
+            cp.on('exit', () => {
+              server.status = 'stopped';
+              closeResolve();
+            });
+            cp.kill('SIGINT');
+            server.status = 'closing';
+          });
+        },
+        results: async () => {
+          const results = await Promise.allSettled([
+            readFile(join(opts.cwd, 'results', 'output.txt'), { encoding: 'utf8' }),
+            readFile(join(opts.cwd, 'results', 'profile.svg'), { encoding: 'utf8' }),
+            readFile(join(opts.cwd, 'results', 'perf.data')),
+            readFile(join(opts.cwd, 'results', 'metadata.json'), { encoding: 'utf8' }),
+            readFile(join(opts.cwd, 'results', 'package-lock.json'), { encoding: 'utf8' })
+          ]);
+
+          if (results[3].value) {
+            Object.assign(server.metadata, JSON.parse(results[3].value));
+          } else {
+            Object.assign(server.metadata, { error: results[3].error });
+          }
+          
+          return {
+            output: results[0].value || results[0].error,
+            flamegraph: results[1].value || results[1].error,
+            rawPerfData: results[2].value || results[2].error,
+            lockfile: results[4].value || results[4].error
+          };
+        }
+      };
+
+      opts?.signal.addEventListener('abort', () => {
+        server.status = 'aborted';
+        cp.kill('SIGINT');
+        reject(new Error('aborted'));
+      });
+      
+      cp.on('error', reject);
+      cp.stdout.on('data', (d) => {
+        process.stdout.write(d);
+        if (server.status === 'starting' && d.toString('utf8').includes("Running")) {
+          server.status = 'started';
+          resolve(server);
+        }
+      });
+      cp.stderr.on('data', (d) => process.stderr.write(d));
+    });
+  }
+
+  async function startClient(_opts = {}, server) {
+    const opts = { ..._opts };
+    if (opts?.signal.aborted) return;
+
+    const cannon = ac({
+      url: server.metadata.url.toString(),
+      requests: await (await import(opts.test)).requests()
+    });
+
+    opts?.signal.addEventListener('abort', () => {
+      console.log('should stop client')
+      cannon.stop?.();
+    });
+
+    return {
+      metadata: collectMetadata(),
+      close: async () => cannon.stop?.(),
+      results: () => cannon
+    };
+  }
+
+  async function runner(_opts = {}) {
+    const opts = { ..._opts };
+
+    const containerMeta = await buildContainer(opts);
+    opts.node = containerMeta.node;
+    opts.tag = containerMeta.tag;
+
+    const server = await startServer(opts);
+    const client = await startClient(opts, server); 
+
+    const clientResults = await client.results();
+    const serverResults = await server.results();
+
+    await client.close();
+    await server.close();
+
+    return {
+      serverMetadata: server.metadata,
+      clientMetadata: client.metadata,
+      serverResults,
+      clientResults
+    };
+  }
+
+  return runner;
+}

--- a/packages/runner-shared/metadata-bundle.mjs
+++ b/packages/runner-shared/metadata-bundle.mjs
@@ -1,0 +1,17 @@
+import process from 'node:process';
+import os from 'node:os';
+
+function collectMetadata () {
+  return {
+    arch: os.arch(),
+    cpus: os.cpus(),
+    machine: os.machine(),
+    platform: os.platform(),
+    release: os.release(),
+    totalmem: os.totalmem(),
+    type: os.type(),
+    version: os.version()
+  };
+}
+
+process.stdout.write(JSON.stringify(collectMetadata()));

--- a/packages/runner-shared/metadata.mjs
+++ b/packages/runner-shared/metadata.mjs
@@ -1,0 +1,4 @@
+import process from 'node:process';
+import { collectMetadata } from '@expressjs/perf-metadata';
+
+process.stdout.write(JSON.stringify(collectMetadata()));

--- a/packages/runner-shared/overrides.mjs
+++ b/packages/runner-shared/overrides.mjs
@@ -1,0 +1,28 @@
+import { parseArgs } from 'node:util';
+
+let data = '';
+for await (const chunk of process.stdin) {
+  data += chunk;
+}
+let pkg = {};
+let overrides = {};
+try {
+  pkg = JSON.parse(data);
+  const args = parseArgs({ allowPositionals: true });
+  overrides = JSON.parse(args.positionals[0]);
+} catch (e) {
+  console.error(e, data);
+}
+
+for (const [dep, spec] of Object.entries(overrides)) {
+  if (pkg.dependencies[dep]) {
+    pkg.dependencies[dep] = spec;
+  }
+}
+
+pkg.overrides = {
+  ...(pkg.overrides ?? {}),
+  ...overrides
+};
+
+process.stdout.write(JSON.stringify(pkg, null, 2) + '\n');

--- a/packages/runner-shared/package.json
+++ b/packages/runner-shared/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@expressjs/perf-runner-shared",
+  "version": "1.0.0", 
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": ["express", "performance", "benchmark", "docker", "runner"],
+  "author": "",
+  "license": "ISC", 
+  "description": "Shared utilities and scripts for Express performance runners",
+  "dependencies": {
+    "@expressjs/perf-autocannon": "^1.0.0",
+    "@expressjs/perf-metadata": "^1.0.0", 
+    "@pkgjs/nv": "^0.2.2"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "rollup": "^4.46.2"
+  }
+}

--- a/packages/runner-shared/scripts/build.sh
+++ b/packages/runner-shared/scripts/build.sh
@@ -1,0 +1,69 @@
+#! /bin/bash
+
+# Always required to run
+if [ -z "$1" ]; then
+  echo "Node version is required. (\$1)"
+  exit 1;
+fi;
+if [ -z "$2" ]; then
+  echo "Node base os is required. (\$2)"
+  exit 1;
+fi;
+if [ -z "$3" ]; then
+  echo "Runner type is required. (\$3)"
+  exit 1;
+fi;
+
+# Build metadata bundle (from runner-shared directory)
+cd "$(dirname "$0")/.."
+rollup metadata.mjs --file metadata-bundle.mjs --plugin @rollup/plugin-node-resolve
+
+# Start docker daemon if not running
+if (! docker stats --no-stream >/dev/null 2>&1 ); then
+  # On Mac OS this would be the terminal command to launch Docker
+  open /Applications/Docker.app
+ #Wait until Docker daemon is running and has completed initialisation
+while (! docker stats --no-stream ); do
+  # Docker takes a few seconds to initialize
+  echo "Waiting for Docker to launch..."
+  sleep 1
+done
+fi
+
+NODE_VERSION=$1
+NODE_BASE=$2
+RUNNER_TYPE=$3
+TAG="expf-runner-${RUNNER_TYPE}:${NODE_VERSION}-${NODE_BASE}"
+
+# Check if runner directory exists (relative to packages dir)
+RUNNER_DIR="../runner-${RUNNER_TYPE}"
+if [ ! -d "$RUNNER_DIR" ]; then
+  echo "Runner directory not found: $RUNNER_DIR"
+  exit 1
+fi
+
+FORCE=
+while test $# -gt 0; do
+  case "$1" in
+    -f|--force)
+      FORCE="true"
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$FORCE" ] || [ -z "$(docker images -q $TAG 2> /dev/null)" ]; then
+  echo "Building container: $TAG"
+  # Use packages directory as build context, specify dockerfile relative to build context
+  cd ..
+  docker build -f "runner-${RUNNER_TYPE}/Dockerfile" . \
+    --build-arg NODE_VERSION=${NODE_VERSION} \
+    --build-arg NODE_BASE=${NODE_BASE} \
+    --build-arg RUNNER_TYPE=${RUNNER_TYPE} \
+    --tag "$TAG"
+  docker tag $TAG "expf-runner-${RUNNER_TYPE}:latest"
+else
+  echo "Using existing container: $TAG"
+fi

--- a/packages/runner-shared/scripts/run.sh
+++ b/packages/runner-shared/scripts/run.sh
@@ -1,0 +1,85 @@
+#! /bin/bash
+SOURCE=${BASH_SOURCE[0]:-$0}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+IS_TERM=false
+if [ -t 1 ]; then
+  IS_TERM=true
+fi
+
+CWD=${1:-$(realpath $DIR/../../../)}
+REPO=${2:-"https://github.com/expressjs/perf-wg.git"}
+REF=${3:-"main"}
+TEST=${4:-"@expressjs/perf-servers/node-http"}
+TAG=${5:-"expf-runner-vanilla:latest"}
+OVERRIDES="${6}"
+
+# Start docker daemon if not running
+if (! docker stats --no-stream >/dev/null 2>&1 ); then
+  # On Mac OS this would be the terminal command to launch Docker
+  open /Applications/Docker.app
+ # Wait until Docker daemon is running and has completed initialisation
+  while (! docker stats --no-stream ); do
+    # Docker takes a few seconds to initialize
+    echo "Waiting for Docker to launch..."
+    sleep 1
+  done
+fi
+
+# Clean up results folder
+mkdir -p "$CWD/results"
+rm "$CWD/results/*" 2> /dev/null || true
+
+# If we are in an interactive terminal, run directly with -it
+if [ $IS_TERM == true ]; then
+  docker run --rm -it \
+    --cap-add=SYS_ADMIN \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    --env "REPO=$REPO" \
+    --env "REF=$REF" \
+    --env "TEST=$TEST" \
+    --env "OVERRIDES=$OVERRIDES" \
+    --volume "$CWD:/home/node/repo" \
+    --volume "$CWD/results:/home/node/results" \
+    -p 3000:3000 \
+    -p 9229:9229 \
+    ${TAG}
+else
+  # If we are not in an interactive terminal, we have
+  # to run a more complicated setup
+  ID=$(docker run --rm -d \
+    --cap-add=SYS_ADMIN \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    --env NO_SPIN=1 \
+    --env "REPO=$REPO" \
+    --env "REF=$REF" \
+    --env "TEST=$TEST" \
+    --env "OVERRIDES=$OVERRIDES" \
+    --volume "$CWD:/home/node/repo" \
+    --volume "$CWD/results:/home/node/results" \
+    -p 3000:3000 \
+    -p 9229:9229 \
+    ${TAG})
+
+  on_sigint()
+  {
+    docker kill --signal="SIGINT" "$ID" >/dev/null 2>&1
+  }
+  trap on_sigint SIGINT
+  docker logs --follow "$ID" &
+  while true
+  do
+    if [ "$(docker container inspect -f '{{.State.Running}}' "$ID" 2>/dev/null)" != "true" ]; then
+      echo "Container exited (${ID})"
+      exit;
+    fi
+    sleep 1
+  done
+fi

--- a/packages/runner-shared/scripts/start.sh
+++ b/packages/runner-shared/scripts/start.sh
@@ -1,0 +1,194 @@
+#! /bin/bash
+set -e
+
+# Always require the server to run
+if [ -z "$TEST" ]; then
+  echo "\$TEST is required."
+  exit 1;
+fi;
+
+#
+# Write out metadata file
+#
+node metadata.mjs > ./results/metadata.json
+
+# We can mount the path for local dev,
+# If not, require a repo and ref
+REPO_DIR="./repo"
+if [ -d "$REPO_DIR" ]; then
+  echo "Using local benchmarks"
+  cd "$REPO_DIR"
+else
+  if [ -z "$REPO" ]; then
+    echo "\$REPO is required."
+    exit 1;
+  fi;
+
+  if [ -z "$REF" ]; then
+    echo "\$REF is required."
+    exit 1;
+  fi;
+
+  #
+  # Benchmark repo setup
+  #
+  cd $REPO_DIR
+  git init
+  git remote add origin "$REPO"
+  git fetch origin --depth=1 "$REF"
+  git fetch checkout "$REF"
+fi;
+
+
+# A little spinner
+SPIN=( ⠁ ⠂ ⠄ ⡀ ⢀ ⠠ ⠐ ⠈  )
+spinner()
+{
+  if [ -z "$NO_SPIN" ]; then
+    for i in "${SPIN[@]}"
+    do
+      echo -ne "\b$i"
+      sleep 0.1
+    done
+  else
+    echo -ne "."
+    sleep 1
+  fi
+}
+
+# cd into server 
+cd $(node -p "require('node:path').dirname(require.resolve(\"$TEST\"))")
+
+# Apply overrides to package.json
+if [ -f "package.json.bak" ]; then
+  echo "package.json.bak exists, restoring original"
+  mv -f package.json.bak package.json
+fi
+if [ -n "$OVERRIDES" ]; then
+  cp package.json package.json.bak
+  ( rm -f package.json && node ~/overrides.mjs "${OVERRIDES}" > package.json ) < package.json;
+fi
+
+# Run server setup
+echo "Running setup..."
+node --run setup || npm run setup
+
+#
+# Configure runtime-specific settings
+#
+RUNTIME_TYPE=${RUNTIME_TYPE:-"vanilla"}
+NODE_OPTIONS=""
+RUNTIME_PREFIX=""
+
+echo "Configuring runtime: $RUNTIME_TYPE"
+
+case "$RUNTIME_TYPE" in
+  "datadog")
+    echo "Setting up Datadog APM..."
+    NODE_OPTIONS="--require dd-trace/init"
+    export DD_TRACE_ENABLED=true
+    export DD_PROFILING_ENABLED=true
+    export DD_SERVICE="express-benchmark"
+    export DD_ENV="benchmark"
+    ;;
+  "newrelic")
+    echo "Setting up New Relic APM..."
+    NODE_OPTIONS="--require newrelic"
+    export NEW_RELIC_APP_NAME="express-benchmark"
+    export NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY:-dummy}"
+    export NEW_RELIC_NO_CONFIG_FILE=true
+    ;;
+  "dynatrace")
+    echo "Setting up Dynatrace APM..."
+    NODE_OPTIONS="--require @dynatrace/oneagent"
+    ;;
+  "nsolid")
+    echo "Using N|Solid runtime..."
+    # N|Solid uses different CLI and doesn't need --require
+    RUNTIME_PREFIX="nsolid"
+    ;;
+  "vanilla"|*)
+    echo "Using vanilla Node.js..."
+    # No additional configuration needed
+    ;;
+esac
+
+#
+# Start server
+#
+PKG=$(cat package.json)
+if echo $PKG | jq -er ".exports.server" &> /dev/null; then
+  PKG_MAIN=$(echo $PKG | jq -r ".exports.server")
+else
+  PKG_MAIN=$(echo $PKG | jq -r ".main")
+fi
+MAIN=${PKG_MAIN:-index.js}
+
+# Choose the runtime executable
+RUNTIME_CMD=${RUNTIME_PREFIX:-node}
+
+echo "Starting server with $RUNTIME_CMD (runtime: $RUNTIME_TYPE)"
+$RUNTIME_CMD $NODE_OPTIONS \
+  --interpreted-frames-native-stack \
+  --perf-basic-prof-only-functions \
+  --inspect=0.0.0.0:9229 \
+  "$MAIN" \
+  &> ./results/output.txt &
+SERVER_PID=$!
+
+# Start perf
+perf record -F 99 -g -o ./results/perf.data -p $SERVER_PID &> ./results/perf.txt &
+PERF_PID=$!
+
+on_sigint()
+{
+  echo
+  echo "Capture ending heap snapshot"
+  npx -q @mmarchini/observe heap-snapshot -p ${SERVER_PID} --file ./results/end.heapsnapshot
+
+  echo "Closing server"
+  kill -2 "$SERVER_PID" || true
+  wait "$PERF_PID" || true
+  local EX=$?
+
+  echo "Generating flamegraph"
+  perf script -i ./results/perf.data | ./FlameGraph/stackcollapse-perf.pl | ./FlameGraph/flamegraph.pl --colors=js > ./results/profile.svg
+
+  EXIT_CODE=${EX:-0}
+}
+trap on_sigint SIGINT
+
+echo "Starting server (server ${SERVER_PID}, perf ${PERF_PID})"
+while true; do
+  # Server process exited
+  if ! [ -d "/proc/${SERVER_PID}" ]; then
+    echo "Exited prematurely (pid ${SERVER_PID}, code ${EXIT_CODE-unknown})"
+    wait $SERVER_PID || true
+    cat ./results/output.txt
+    EXIT_CODE=1
+    break
+  fi
+  if grep -q "startup: " <(head ./results/output.txt); then
+    echo "Capture starting heap snapshot"
+    npx -q @mmarchini/observe heap-snapshot -p ${SERVER_PID} --file ./results/start.heapsnapshot
+    break
+  fi
+done
+
+echo -ne "Running..."
+while true; do
+  if [ -n "$EXIT_CODE" ]; then
+
+    if [ -f "package.json.bak" ]; then
+      echo "restoring original package.json"
+      mv -f package.json.bak package.json
+    fi
+
+    echo "moving package-lock.json to results"
+    mv package-lock.json ./results/package-lock.json
+
+    echo "Exiting (${EXIT_CODE})"
+    exit "${EXIT_CODE-0}"
+  fi
+  spinner
+done

--- a/packages/runner-vanilla/Dockerfile
+++ b/packages/runner-vanilla/Dockerfile
@@ -1,0 +1,39 @@
+# Node Settings
+ARG NODE_VERSION="lts"
+ARG NODE_BASE="bookworm"
+ARG RUNNER_TYPE="vanilla"
+
+FROM node:${NODE_VERSION}-${NODE_BASE}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      linux-perf=6.1.147-1 \
+      jq=1.6-2.1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup @mmarchini/observe
+RUN <<-EOF
+  npm install -g @mmarchini/observe@^3.0.0
+  chown -R node:node /usr/local/lib/node_modules
+  chown -R node:node /usr/local/bin/observe
+EOF
+
+USER node
+WORKDIR /home/node
+
+# Setup FlameGraph tools
+RUN git clone https://github.com/brendangregg/FlameGraph.git
+
+VOLUME ["/home/node/repo"]
+VOLUME ["/home/node/results"]
+EXPOSE 3000 9229
+
+# Copy shared utilities directly from runner-shared
+COPY runner-shared/metadata-bundle.mjs metadata.mjs
+COPY runner-shared/overrides.mjs overrides.mjs
+COPY runner-shared/scripts/start.sh start.sh
+
+# Set runtime type for this container
+ENV RUNTIME_TYPE=vanilla
+
+ENTRYPOINT ["./start.sh"]

--- a/packages/runner-vanilla/index.mjs
+++ b/packages/runner-vanilla/index.mjs
@@ -1,0 +1,11 @@
+import { createRunner } from '@expressjs/perf-runner-shared';
+
+export default createRunner({
+  type: 'vanilla',
+  runtime: 'node.js',
+  apm: 'none',
+  capabilities: ['profiling', 'flamegraphs', 'heap-snapshots', 'perf-data'],
+  env: {
+    RUNTIME_TYPE: 'vanilla'
+  }
+});

--- a/packages/runner-vanilla/package.json
+++ b/packages/runner-vanilla/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@expressjs/perf-runner-vanilla",
+  "version": "1.0.0",
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "node --run build",
+    "build": "node --run shared:build",
+    "run": "node --run shared:run",
+    "shared:build": "../runner-shared/scripts/build.sh 22.18.0 bookworm vanilla",
+    "shared:run": "../runner-shared/scripts/run.sh"
+  },
+  "keywords": ["express", "performance", "benchmark", "vanilla", "node"],
+  "author": "",
+  "license": "ISC",
+  "description": "Vanilla Node.js runner for Express performance benchmarks",
+  "dependencies": {
+    "@expressjs/perf-runner-shared": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Summary
Introduces a flexible multi-runner architecture for Express performance testing, enabling evaluation of different Node.js runtimes and APM vendors with consistent tooling.

### 🚀 Key Features
Multi-Runtime Support: Vanilla Node.js and N|Solid runtime runners
Dual Usage: CLI (--runner="@expressjs/perf-runner-nsolid") and programmatic imports
Package Overrides: Test with different Express versions (--overrides='{"express":"5.0.0"}')
Performance Comparison: Built-in result analysis and overhead measurement

### 📦 Architecture
```
packages/
├── runner-shared/     # Common utilities and base runner
├── runner-vanilla/    # Standard Node.js runner  
└── runner-nsolid/     # N|Solid runtime with monitoring
```
### 🎯 Usage
bash
#### Node Runner
node --run load --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-vanilla" --overrides='{"express":"5.0.0"}'

#### N|Solid Runner
node --run load --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-nsolid" --overrides='{"express":"5.0.0"}'

