### PR TITLE
feat(cli): add --config and --[no-]write options

### DIFF
--- a/expf.config.json
+++ b/expf.config.json
@@ -1,0 +1,3 @@
+{
+  "write": false
+}

--- a/packages/cli/bin/expf.mjs
+++ b/packages/cli/bin/expf.mjs
@@ -4,6 +4,7 @@ import { argv } from 'node:process';
 const { values, positionals } = parseArgs({
   args: argv,
   allowPositionals: true,
+  allowNegative: true,
   options: {
     help: {
       type: 'boolean'
@@ -37,6 +38,15 @@ const { values, positionals } = parseArgs({
     overrides: {
       type: 'string',
       short: 'o'
+    },
+
+    config: {
+      type: 'string',
+      short: 'c'
+    },
+
+    write: {
+      type: 'boolean'
     }
   }
 });


### PR DESCRIPTION
Added a `--config` option which loads `./expf.config.json` by default. Also added that file here with `write: false` (a new option) to disable writing results files in this repo. For now it feels like that is a good default since we are not going to safe those files until we get more reliable tests in place, and you can simply override it with `--write` for ones you want to use to `compare` while we test with.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
