### PR TITLE
docs: add Performance Working Group meetings notes for from 2025-09-03 to 2025-11-12

### DIFF
--- a/meetings/2025-09-03.md
+++ b/meetings/2025-09-03.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-09-03
+
+### Information
+
+- We didn't take notes to share in this meeting, sorry.

--- a/meetings/2025-09-17.md
+++ b/meetings/2025-09-17.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-09-17
+
+### Information
+
+- We didn't take notes to share in this meeting, sorry.

--- a/meetings/2025-10-01.md
+++ b/meetings/2025-10-01.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-10-01
+
+### Information
+
+- We didn't take notes to share in this meeting, sorry.

--- a/meetings/2025-10-15.md
+++ b/meetings/2025-10-15.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-10-15
+
+### Information
+
+- This meeting was skipped because most of the team was at JS Conf and there wasn’t much new progress to discuss that week.

--- a/meetings/2025-10-29.md
+++ b/meetings/2025-10-29.md
@@ -1,0 +1,6 @@
+# Performance Working Group Meeting Notes – 2025-10-29
+
+### Information
+
+- This meeting was skipped because key participants were traveling and attending Github Universe event, so no one was available to join.
+

--- a/meetings/2025-11-12.md
+++ b/meetings/2025-11-12.md
@@ -1,0 +1,63 @@
+# Performance Working Group Meeting Notes – 2025-11-12
+
+### Meta Information
+
+- GitHub Issue: [#67](https://github.com/expressjs/perf-wg/issues/67)
+
+### Discussions at the Meeting
+
+- **Dashboards and APM Integration** ([Issue #28](https://github.com/expressjs/perf-wg/issues/28)):
+  - **NodeSource APM Integration**:
+    - Using built-in dashboarding from APM partners for initial implementation
+  
+  - **Partnership with Multiple APM Vendors**:
+    - [@wesleytodd](https://github.com/wesleytodd) talked at JSConf in October with potential partners
+    - Goal is to partner with New Relic, Datadog, and Sentry in addition to NodeSource
+    - Important for long-term sustainability since Express is underfunded and relies on volunteers
+    - STA funding exists to get performance monitoring across the finish line this year
+    - After initial funding, project needs APM vendor partnerships to maintain infrastructure without dedicated resources
+  
+  - **Dashboard Development Work**:
+    - Need to output standard format from APM integrations to build static dashboard
+    - Dashboard should compare CI integration results with baseline (latest Express version)
+    - [@groophylifefor](https://github.com/groophylifefor) volunteered to work on front-end webpage for comparing data
+    - First iteration doesn't need complex graphs, just clear comparison of metrics showing improvement or regression
+    - Need to define standard output format
+
+- **CI Integration Technical Plan**:
+  - Talked about technical plan for getting CI integration done by end of year
+  - Goal is to run performance tests on-demand for PRs and compare against baseline
+  - Results will be shown in PRs in a clear format
+  - [@wesleytodd](https://github.com/wesleytodd) shared issue #67 in chat for technical plan details
+
+- **Benchmarking References**:
+  - [@rafaelgss](https://github.com/rafaelgss) shared Fastify benchmark examples:
+    - Fastify benchmarks workflow: https://github.com/fastify/benchmarks/blob/main/.github/workflows/benchmarks.yml
+    - Fastify PR benchmark workflow: https://github.com/RafaelGSS/fastify/blob/8cd2340c24fcc1802665c43546147dd067c6e9e4/.github/workflows/benchmark.yml
+  - [@ulisesgascon](https://github.com/ulisesgascon) expressed support (+60 in chat)
+
+- **Data Format Discussion**:
+  - [@groophylifefor](https://github.com/groophylifefor) asked about sample data format for comparison work
+  - Talked about whether browsers can handle large JSON files for dashboard
+  - Need to set up a standard output format from performance testing tools
+
+---
+
+### Shared Resources
+
+- **Meeting Agenda** – Technical plan for CI integration: [#67](https://github.com/expressjs/perf-wg/issues/67)
+- **Dashboard Discussion** – APM integration and UI work: [#28](https://github.com/expressjs/perf-wg/issues/28)
+- **Fastify Benchmarks** – Reference implementation: https://github.com/fastify/benchmarks/blob/main/.github/workflows/benchmarks.yml
+- **Fastify PR Benchmark** – Example workflow: https://github.com/RafaelGSS/fastify/blob/8cd2340c24fcc1802665c43546147dd067c6e9e4/.github/workflows/benchmark.yml
+
+---
+
+### Call to Action
+
+- **Volunteer for dashboard UI work**: Help create the front-end interface for comparing performance metrics between PRs and baseline. Contact [@groophylifefor](https://github.com/groophylifefor) if interested in working together.
+- **Help define standard output format**: Help define the standard data format for performance test results that will be used across different APM integrations.
+- **Review CI integration technical plan**: Give feedback on issue #67 for the end-of-year CI integration plan.
+- **Join the discussion**: Participate in bi-weekly meetings (Wednesdays) or contribute to open issues in the [perf-wg repository](https://github.com/expressjs/perf-wg).
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊


### PR DESCRIPTION
This pull request adds detailed meeting notes for the Performance Working Group's meetings from 2025-09-03 to 2025-11-12.