### PR TITLE
docs: add meeting notes for 2025-11-26 and 2025-12-24

### DIFF
--- a/meetings/2025-11-26.md
+++ b/meetings/2025-11-26.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-11-26
+
+### Information
+
+- This meeting was skipped due to the US holiday.

--- a/meetings/2025-12-10.md
+++ b/meetings/2025-12-10.md
@@ -1,0 +1,43 @@
+# Performance Working Group Meeting Notes – 2025-12-10
+
+### Meta Information
+
+- GitHub Issue: [#<number>](https://github.com/expressjs/perf-wg/issues/<number>)
+
+
+### Discussions at the Meeting
+
+- **Dashboard Demo**
+  - [@GroophyLifefor](https://github.com/GroophyLifefor) presented the progress on the performance dashboard.
+  - The JSON output was optimized by removing unnecessary data to reduce file size.
+  - The dashboard architecture involves fetching baseline JSON and comparing it with current results.
+  - Flamegraphs are generated as SVGs and handled in the client for comparison.
+  - [@wesleytodd](https://github.com/wesleytodd) provided positive feedback and suggested moving to code review.
+
+- **CI Integration and Data Format**
+  - [@wesleytodd](https://github.com/wesleytodd) discussed the CI integration Pull Request.
+  - A change was introduced to make client results an array, which affects how the dashboard consumes data.
+  - There was a discussion on whether to include multiple request formats (e.g., root `/` vs `/foo`) in the benchmarks.
+  - If the array format is retained, the dashboard and result files will need to be updated to handle it.
+  - [@GroophyLifefor](https://github.com/GroophyLifefor) mentioned he might back out the change to simplify the merge or proceed with the necessary updates.
+
+- **Standard Deviation Metrics**
+  - [@wesleytodd](https://github.com/wesleytodd) raised a question about how standard deviation changes are visualized (e.g., whether a decrease is marked as "improved").
+  - [@GroophyLifefor](https://github.com/GroophyLifefor) explained the current implementation and agreed to adjust the logic based on feedback during the review.
+
+---
+
+### Shared Resources
+
+- **Dashboard Demo** – Presentation of the current state of the performance dashboard.
+- **CI Integration PR** – Updates on the CI integration work.
+
+---
+
+### Call to Action
+
+- Review the Dashboard PR.
+- Review the CI Integration PR.
+- Decide on the data format for benchmark results (single vs multiple requests).
+
+> Thank you to everyone who participated 😊

--- a/meetings/2025-12-24.md
+++ b/meetings/2025-12-24.md
@@ -1,0 +1,5 @@
+# Performance Working Group Meeting Notes – 2025-12-24
+
+### Information
+
+- This meeting was skipped due to the Christmas Eve.


### PR DESCRIPTION
This pull request adds meeting notes for several Performance Working Group meetings. It documents discussions and decisions from the December 10, 2025 meeting and notes skipped meetings due to holidays.

Meeting notes updates:

* Added detailed notes for the 2025-12-10 meeting, including discussion of the performance dashboard demo, CI integration and data format changes, and standard deviation metrics. Action items and shared resources are also included.
* Added entries noting that the meetings on 2025-11-26 and 2025-12-24 were skipped due to the US holiday and Christmas Eve, respectively. 