### PR TITLE
feat: include some options in the local runner metadata

### DIFF
--- a/packages/requests/index.mjs
+++ b/packages/requests/index.mjs
@@ -67,7 +67,7 @@ export function startLoad (opts = {}) {
     },
     results: async () => {
       const r = await Promise.allSettled(toAwait);
-      return r.reduce((a, r) => {
+      const results = r.reduce((a, r) => {
         if (r.status === 'rejected') {
           if (r.reason.code !== 'EXECUTABLE_NOT_PRESENT') {
             throw r.reason;
@@ -78,6 +78,10 @@ export function startLoad (opts = {}) {
         }
         return a;
       }, []);
+      if (results.length === 0) {
+        throw new AggregateError(r.map((p) => p.reason), 'all clients failed')
+      }
+      return results;
     }
   };
 }

--- a/packages/runner-local-docker/index.mjs
+++ b/packages/runner-local-docker/index.mjs
@@ -179,6 +179,12 @@ export function createRunner (runnerConfig = {}) {
     await server.close();
 
     return {
+      options: {
+        runner: `local-docker-${name}`,
+        node: opts.node,
+        overrides: opts.overrides,
+        test: opts.test
+      },
       serverMetadata: server.metadata,
       clientMetadata: client.metadata,
       serverResults,

--- a/packages/runner-local/index.mjs
+++ b/packages/runner-local/index.mjs
@@ -36,6 +36,12 @@ export default async function runner (_opts = {}) {
   await cleanup(cwd);
 
   return {
+    options: {
+      runner: 'local',
+      node: opts.node,
+      overrides: opts.overrides,
+      test: opts.test
+    },
     serverMetadata: server.metadata,
     clientMetadata: client.metadata,
     serverResults,


### PR DESCRIPTION
Added relevant options (node version, runner type, overrides) to the `results.json`.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
