### PR TITLE
fix(ci): narrow down load test trigger on PRs to specific file paths

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,13 @@
 name: PR
 on:
   pull_request:
+    paths:
+      - 'package[-lock].json'
+      - '.github/workflows/**'
+      - 'expf.config.json'
+      - 'packages/**'
+      - 'servers/**'
+      - 'perf/load/**'
   workflow_call:
 
 jobs:


### PR DESCRIPTION
This should be the files that impact the load testing setup so we don't get load tests running for docs/notes/misc changes.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
