### PR TITLE
feat(cli): add --output flag to load command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.mjs text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The `load` command supports the following options:
 | `--overrides` | `-o` | - | JSON string with package overrides |
 | `--config` | `-c` | - | JSON string with package overrides |
 | `--[no-]write` | - | - | Write results file to disk |
+| `--output` | - | `/results/result-<timestamp>.json` | Output file path for results (implies write) |
 | `--force-rebuild` | - | - | For use with docker based runners, forces rebuilding container |
 
 #### Basic Commands
@@ -164,6 +165,56 @@ node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/pe
 
 # Node.js with New Relic APM (when available)
 node --run load -- --test="@expressjs/perf-load-example" --runner="@expressjs/perf-runner-newrelic"
+```
+
+#### Compare latest Express with a PR branch 
+
+##### Run benchmark against latest Express
+
+```bash
+node --run load -- --test="@expressjs/perf-load-extended-query" --overrides='{"express":"latest"}' --output=latest.json
+```
+
+##### Run benchmark against a PR branch
+
+PR from format:
+
+```txt
+<owner>/<repo>#<branch>
+```
+
+Example:
+
+```bash
+node --run load -- --test="@expressjs/perf-load-extended-query" --overrides='{"express":"GroophyLifefor/express#no-store-no-etag"}' --output=pr.json
+```
+
+##### Compare results
+
+```bash
+node --run compare -- latest.json pr.json
+```
+
+##### Example output
+
+```txt
+Comparison: B Wins
+==================
+{
+  diff: { rps: '-6.84%', throughput: '-6.83%', latency: '9.11%' },
+  a: {
+    avgRPS: 17562.6,
+    avgThroughput: 5918720,
+    avgLatency: 5.03,
+    status: { '200': { count: 1053729 } }
+  },
+  b: {
+    avgRPS: 18851.67,
+    avgThroughput: 6352725.34,
+    avgLatency: 4.61,
+    status: { '200': { count: 1131043 } }
+  }
+}
 ```
 
 ### Programmatic Usage

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,3 +70,20 @@ The `--overrides` flag accepts a JSON object where keys are package names and va
 1. Apply the overrides to both direct dependencies and nested dependencies
 2. Generate a new package-lock.json for reproducibility
 3. Include the lock file in the test results for full transparency
+
+## Running Tests
+
+The CLI has a unit test suite using Node's built-in `node:test` runner. Run from the CLI package directory:
+
+```bash
+cd packages/cli
+npm test
+```
+
+Or from the project root via workspaces:
+
+```bash
+npm test --workspace=@expressjs/perf-cli
+```
+
+Tests cover CLI command behavior using mocked runners and dependencies — no real servers or network calls are needed.

--- a/packages/cli/bin/expf.mjs
+++ b/packages/cli/bin/expf.mjs
@@ -62,6 +62,10 @@ const { values, positionals } = parseArgs({
 
     'force-rebuild': {
       type: 'boolean'
+    },
+
+    output: {
+      type: 'string'
     }
   }
 });

--- a/packages/cli/load.mjs
+++ b/packages/cli/load.mjs
@@ -21,6 +21,7 @@ export function help (opts = {}) {
     --overrides='{"express":"latest"}'
     --config=./expf.config.json
     --[no-]write
+    --output=./path/to/result.json
     --[no-]parallel
 
   Runners:
@@ -154,8 +155,8 @@ export default function main (_opts = {}) {
       signal: ac.signal
     });
 
-    if (opts.write !== false) {
-      const outputFile = join(dirname(import.meta.resolve(opts.test).replace(/^file:/, '')), 'results', 'result-' + Date.now() + '.json');
+    if (opts.output != null || opts.write !== false) {
+      const outputFile = opts.output ?? join(dirname(import.meta.resolve(opts.test).replace(/^file:/, '')), 'results', 'result-' + Date.now() + '.json');
       await mkdir(dirname(outputFile), { recursive: true });
       await writeFile(outputFile, JSON.stringify(results, null, 2));
       console.log(`written to: ${outputFile}`);

--- a/packages/cli/load.mjs
+++ b/packages/cli/load.mjs
@@ -38,7 +38,7 @@ export function help (opts = {}) {
       Path to configuration file
 
     --[no-]write
-      Whether to write results to disk
+      Whether to write results to file
 
     --output=./path/to/result.json
       Path to output file

--- a/packages/cli/load.mjs
+++ b/packages/cli/load.mjs
@@ -38,7 +38,10 @@ export function help (opts = {}) {
       Path to configuration file
 
     --[no-]write
+      Whether to write results to disk
+
     --output=./path/to/result.json
+      Path to output file
     
     --[no-]parallel
       Whether to run tests in parallel

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "bin/expf.mjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test --experimental-test-module-mocks test/*.test.mjs",
     "lint": "semistandard",
     "lint:fix": "semistandard --fix"
   },

--- a/packages/cli/test/fixtures/mock-runner.mjs
+++ b/packages/cli/test/fixtures/mock-runner.mjs
@@ -1,0 +1,18 @@
+export function help() {
+  return 'mock runner for testing';
+}
+
+export default async function mockRunner(_opts) {
+  return {
+    clientResults: [{
+      url: 'http://localhost:3000/',
+      '2xx': 1000,
+      non2xx: 0,
+      errors: 0,
+      requests: { sent: 1000 },
+      latency: { average: 10, max: 50, min: 1, stddev: 5 },
+      throughput: { average: 100 },
+      duration: 10
+    }]
+  };
+}

--- a/packages/cli/test/load.test.mjs
+++ b/packages/cli/test/load.test.mjs
@@ -1,0 +1,79 @@
+import { mock, test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+mock.module('@pkgjs/nv', {
+  defaultExport: async () => [{ version: '22.0.0' }]
+});
+
+mock.module('autocannon', {
+  defaultExport: {
+    printResult: () => 'mock autocannon result'
+  }
+});
+
+const mockRunnerPath = import.meta.resolve('./fixtures/mock-runner.mjs');
+const loadModule = await import('../load.mjs');
+const { default: main } = loadModule;
+
+let tmpDir;
+
+afterEach(async () => {
+  if (tmpDir) {
+    await rm(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+test('--output writes results to the specified file', async (t) => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'expf-test-'));
+  const outputFile = join(tmpDir, 'result.json');
+
+  const ac = new AbortController();
+
+  await main({
+    output: outputFile,
+    test: '@expressjs/perf-load-example',
+    runner: mockRunnerPath,
+    abortController: ac,
+    write: true
+  });
+
+  const fileContents = await readFile(outputFile, 'utf-8');
+  const parsed = JSON.parse(fileContents);
+
+  assert.ok(parsed.clientResults, 'results should contain clientResults');
+  assert.strictEqual(parsed.clientResults.length, 1);
+  assert.strictEqual(parsed.clientResults[0].url, 'http://localhost:3000/');
+  assert.strictEqual(parsed.clientResults[0]['2xx'], 1000);
+});
+
+test('--no-write prints results to console instead of writing to file', async (t) => {
+  const logSpy = t.mock.method(console, 'log');
+
+  const ac = new AbortController();
+
+  await main({
+    test: '@expressjs/perf-load-example',
+    runner: mockRunnerPath,
+    abortController: ac,
+    write: false
+  });
+
+  const logCalls = logSpy.mock.calls.map(call => call.arguments.join(' '));
+
+  assert.ok(
+    logCalls.some(call => call.includes('http://localhost:3000/')),
+    'console.log should contain the benchmark URL'
+  );
+  assert.ok(
+    logCalls.some(call => call.includes('mock autocannon result')),
+    'console.log should contain autocannon results'
+  );
+  assert.ok(
+    !logCalls.some(call => call.includes('written to:')),
+    'console.log should NOT contain "written to:" when --no-write is set'
+  );
+});


### PR DESCRIPTION
Added support for an `--output` option in the `load` command, allowing users to specify the output file path for benchmark results. Also the `README.md` with a new section and step-by-step examples for comparing benchmarks between the latest Express and a PR branch.