### PR TITLE
Fix markdown formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ async function runPerformanceAnalysis() {
   await fs.writeFile('performance-report.json', JSON.stringify(results, null, 2));
   console.log('Performance analysis complete. Results saved to performance-report.json');
 }
+```
 
 ### Runner Development
 


### PR DESCRIPTION
One code block was missing the closing ` ``` ` and the last section of readme did not render correctly

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
