### PR TITLE
docs: add Performance Working Group meeting notes for 2026-07-22 and 2026-08-05

### DIFF
--- a/meetings/2026-07-22.md
+++ b/meetings/2026-07-22.md
@@ -1,0 +1,29 @@
+# Performance Working Group Meeting Notes – 2026-07-22
+
+### Meta Information
+
+- Attendees: Murat Kirazkaya, Jay (first time), Abdelrahman (first time)
+
+### Discussions at the Meeting
+
+- **Welcome to New Members**:
+  - Jay and Abdelrahman attended for the first time
+  - Since no one else was present, Murat introduced the project to them
+
+- **Project Status Recap**:
+  - Murat explained what the project is, how it's progressing, and its current status
+  - Noted that there has not been any progress on the project itself recently
+
+- **Future Participation**:
+  - Jay and Abdelrahman are motivated to join the group
+  - They expressed interest in attending if the group can regain its former enthusiasm and resume regular meetings
+
+---
+
+### Call to Action
+
+- **Regain momentum**: Restart regular meetings to keep members engaged
+- **Welcome new contributors**: Follow up with Jay and Abdelrahman to onboard them into the project
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊

--- a/meetings/2026-08-05.md
+++ b/meetings/2026-08-05.md
@@ -1,0 +1,20 @@
+# Performance Working Group Meeting Notes – 2026-08-05
+
+### Meta Information
+
+- Attendees: Chris de Almeida
+
+### Discussions at the Meeting
+
+- **Meeting Cancelled**:
+  - Only Chris de Almeida attended
+  - Due to the low attendance, the meeting was cancelled
+
+---
+
+### Call to Action
+
+- **Attend the next meeting**: Mark your calendars for the upcoming session to help keep the group active
+
+> If a mistake has been made, please correct it.
+> Thank you to everyone who participated 😊


### PR DESCRIPTION
This pull request details meeting notes for the Performance Working Group's meetings